### PR TITLE
Refactor: changed search function to use the url to persist on refresh

### DIFF
--- a/client/components/Navbar.js
+++ b/client/components/Navbar.js
@@ -4,7 +4,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { logout } from '../store';
-import { filterPlants } from '../store/searchResults';
+import history from '../history';
 
 class Navbar extends React.Component {
   constructor(props) {
@@ -25,8 +25,7 @@ class Navbar extends React.Component {
     this.setState({
       search: '',
     });
-    const { handleSearch } = this.props;
-    handleSearch(evt.target.search.value);
+    history.push(`/search?query=${evt.target.search.value}`);
   };
 
   render() {
@@ -91,9 +90,6 @@ const mapDispatch = (dispatch) => {
   return {
     handleClick() {
       dispatch(logout());
-    },
-    handleSearch(query) {
-      dispatch(filterPlants(query));
     },
   };
 };

--- a/client/components/SearchResults.js
+++ b/client/components/SearchResults.js
@@ -1,30 +1,52 @@
+/* eslint-disable react/destructuring-assignment */
+/* eslint-disable react/prop-types */
 /* eslint-disable react/jsx-filename-extension */
 import React from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import Plant from './Plant';
+import { filterPlants } from '../store/searchResults';
 
-function SearchResults({ plants }) {
-  return (
-    <>
-      {plants.length ? (
-        <div className="plants-container">
-          {/* But, Sarah, this is the same as Home.
+class SearchResults extends React.Component {
+  componentDidMount() {
+    const { location } = this.props;
+    const { search } = location;
+    const { handleSearch } = this.props;
+    handleSearch(search);
+  }
+
+  componentDidUpdate(prevProps) {
+    const { location } = this.props;
+    const { search } = location;
+    if (prevProps.location.search !== search) {
+      const { handleSearch } = this.props;
+      handleSearch(search);
+    }
+  }
+
+  render() {
+    const { plants } = this.props;
+    return (
+      <>
+        {plants.length ? (
+          <div className="plants-container">
+            {/* But, Sarah, this is the same as Home.
     Yes, but that refactoring can wait. */}
-          {plants.map((plant) => (
-            <Plant key={plant.id} plant={plant} />
-          ))}
-        </div>
-      ) : (
-        <>
-          <h3>
-            Sorry, we have no plants matching that search in our database.
-          </h3>
-          <Link to="/home">You can shop our whole selection here.</Link>
-        </>
-      )}
-    </>
-  );
+            {plants.map((plant) => (
+              <Plant key={plant.id} plant={plant} />
+            ))}
+          </div>
+        ) : (
+          <>
+            <h3>
+              Sorry, we have no plants matching that search in our database.
+            </h3>
+            <Link to="/plants">You can shop our whole selection here.</Link>
+          </>
+        )}
+      </>
+    );
+  }
 }
 
 const mapState = (state) => {
@@ -33,4 +55,12 @@ const mapState = (state) => {
   };
 };
 
-export default connect(mapState)(SearchResults);
+const mapDispatch = (dispatch) => {
+  return {
+    handleSearch(query) {
+      dispatch(filterPlants(query));
+    },
+  };
+};
+
+export default connect(mapState, mapDispatch)(SearchResults);

--- a/client/routes.js
+++ b/client/routes.js
@@ -1,12 +1,12 @@
 /* eslint-disable react/jsx-filename-extension */
-import React, {Component, Fragment} from 'react';
-import {connect} from 'react-redux';
-import {withRouter, Route, Switch, Redirect} from 'react-router-dom';
+import React, { Component, Fragment } from 'react';
+import { connect } from 'react-redux';
+import { withRouter, Route, Switch, Redirect } from 'react-router-dom';
 import Home from './components/Home';
 import SinglePlant from './components/SinglePlant';
 import OrderConfirmation from './components/OrderConfirmation';
 import Cart from './components/Cart';
-import {me} from './store';
+import { me } from './store';
 import AllOrders from './components/AllOrders';
 import AccountInfo from './components/AccountInfo';
 import EditAccount from './components/EditAccount';
@@ -18,12 +18,12 @@ import SearchResults from './components/SearchResults';
  * COMPONENT
  */
 class Routes extends Component {
-	componentDidMount() {
-		this.props.loadInitialData();
-	}
+  componentDidMount() {
+    this.props.loadInitialData();
+  }
 
-	render() {
-		const {isLoggedIn} = this.props;
+  render() {
+    const { isLoggedIn } = this.props;
 
     return (
       <div>
@@ -42,7 +42,7 @@ class Routes extends Component {
             <Route exact path="/account/info" component={AccountInfo} />
             <Route exact path="/account/past-orders" component={AllOrders} />
             <Route exact path="/account/edit" component={EditAccount} />
-            <Route path="/searchResults" component={SearchResults} />
+            <Route path="/search" component={SearchResults} />
             <Route path="/order-confirmation" component={OrderConfirmation} />
             <Route exact path="/account/admin" component={DashBoard} />
             <Redirect to="/home" />
@@ -61,7 +61,7 @@ class Routes extends Component {
                 <SinglePlant plantId={routeProps.match.params.plantId} />
               )}
             />
-            <Route path="/searchResults" component={SearchResults} />
+            <Route path="/search" component={SearchResults} />
             <Route path="/order-confirmation" component={OrderConfirmation} />
             <Redirect to="/login" />
           </Switch>
@@ -75,22 +75,22 @@ class Routes extends Component {
  * CONTAINER
  */
 
-const mapState = state => {
-	return {
-		// Being 'logged in' for our purposes will be defined has having a state.auth that has a truthy id.
-		// Otherwise, state.auth will be an empty object, and state.auth.id will be falsey
-		isLoggedIn: !!state.auth.email,
-		cart: state.cart,
-	};
+const mapState = (state) => {
+  return {
+    // Being 'logged in' for our purposes will be defined has having a state.auth that has a truthy id.
+    // Otherwise, state.auth will be an empty object, and state.auth.id will be falsey
+    isLoggedIn: !!state.auth.email,
+    cart: state.cart,
+  };
 };
 
 // fetch cart
-const mapDispatch = dispatch => {
-	return {
-		loadInitialData() {
-			dispatch(me());
-		},
-	};
+const mapDispatch = (dispatch) => {
+  return {
+    loadInitialData() {
+      dispatch(me());
+    },
+  };
 };
 
 // The `withRouter` wrapper makes sure that updates are not blocked

--- a/client/store/searchResults.js
+++ b/client/store/searchResults.js
@@ -14,11 +14,9 @@ const gotPlants = (plants) => ({
 export const filterPlants = (query) => {
   return async (dispatch) => {
     try {
-      const { data: plants } = await axios.get(
-        `/api/plants/search?like=${query}`
-      );
+      const { data: plants } = await axios.get(`/api/plants/search${query}`);
       dispatch(gotPlants(plants));
-      history.push('/searchResults');
+      // history.push('/searchResults');
     } catch (error) {
       console.error(error);
     }

--- a/server/api/plants.js
+++ b/server/api/plants.js
@@ -1,32 +1,32 @@
-const {response} = require('express');
+const { response } = require('express');
 const express = require('express');
 const { Op } = require('sequelize');
 const router = express.Router();
 const Plant = require('../db/models/plant');
-const {requireToken, isAdmin} = require('./gatekeepingmiddleware');
+const { requireToken, isAdmin } = require('./gatekeepingmiddleware');
 module.exports = router;
 
 // /API/PLANTS shows active plants
 router.get('/', async (req, res, next) => {
-	try {
-		const plants = await Plant.findAll({
-			where: {
-				active: true,
-			},
-		});
-		res.json(plants);
-	} catch (err) {
-		next(err);
-	}
+  try {
+    const plants = await Plant.findAll({
+      where: {
+        active: true,
+      },
+    });
+    res.json(plants);
+  } catch (err) {
+    next(err);
+  }
 });
 // for alll plants on admin dashboard
 router.get('/all', async (req, res, next) => {
-	try {
-		const plants = await Plant.findAll();
-		res.json(plants);
-	} catch (err) {
-		next(err);
-	}
+  try {
+    const plants = await Plant.findAll();
+    res.json(plants);
+  } catch (err) {
+    next(err);
+  }
 });
 /*
 Goal: If plant price is changed, then deactivate plant and create a new instance,
@@ -34,71 +34,71 @@ else update plant information
 This will make our database have a plant history
 */
 router.post('/update', async (req, res, next) => {
-	try {
-		const {plantsList} = req.body;
-		//list for plants with changed price
-		const changedPricePlants = [];
-		//list for plants with changed information excluding price
-		const changedPlants = [];
-		for (let i = 0; i < plantsList.length; i++) {
-			const plant = await Plant.findByPk(plantsList[i].id);
-			if (plant.price === plantsList[i].price * 100)
-				changedPlants.push(plantsList[i]);
-			else {
-				changedPricePlants.push(plantsList[i]);
-			}
-		}
-		//set plants with changed price to deactivate
-		const changing = await Promise.all(
-			changedPricePlants.map(plant => {
-				return Plant.update({active: false}, {where: {id: plant.id}});
-			})
-		);
-		console.log(changing);
-		//creates new plant instance for new priced plants
-		await Promise.all(
-			changedPricePlants.map(plant => {
-				return Plant.create({
-					name: plant.name,
-					species: plant.species,
-					price: plant.price,
-					imageURL: plant.imageURL,
-					description: plant.description,
-					quantity: plant.quantity,
-				});
-			})
-		);
-		//updates a plants information that didnt need a price change
-		await Promise.all(
-			changedPlants.map(plant => {
-				return Plant.update(plant, {where: {id: plant.id}});
-			})
-		);
+  try {
+    const { plantsList } = req.body;
+    //list for plants with changed price
+    const changedPricePlants = [];
+    //list for plants with changed information excluding price
+    const changedPlants = [];
+    for (let i = 0; i < plantsList.length; i++) {
+      const plant = await Plant.findByPk(plantsList[i].id);
+      if (plant.price === plantsList[i].price * 100)
+        changedPlants.push(plantsList[i]);
+      else {
+        changedPricePlants.push(plantsList[i]);
+      }
+    }
+    //set plants with changed price to deactivate
+    const changing = await Promise.all(
+      changedPricePlants.map((plant) => {
+        return Plant.update({ active: false }, { where: { id: plant.id } });
+      })
+    );
+    console.log(changing);
+    //creates new plant instance for new priced plants
+    await Promise.all(
+      changedPricePlants.map((plant) => {
+        return Plant.create({
+          name: plant.name,
+          species: plant.species,
+          price: plant.price,
+          imageURL: plant.imageURL,
+          description: plant.description,
+          quantity: plant.quantity,
+        });
+      })
+    );
+    //updates a plants information that didnt need a price change
+    await Promise.all(
+      changedPlants.map((plant) => {
+        return Plant.update(plant, { where: { id: plant.id } });
+      })
+    );
 
-		const plants = await Plant.findAll();
-		// await plants.reload();
-		res.json(plants);
-	} catch (err) {
-		next(err);
-	}
+    const plants = await Plant.findAll();
+    // await plants.reload();
+    res.json(plants);
+  } catch (err) {
+    next(err);
+  }
 });
 
 // GET filtered plants
 router.get('/search', async (req, res, next) => {
   try {
-    const { like } = req.query;
+    const { query } = req.query;
     const plants = await Plant.findAll({
       where: {
         active: true,
         [Op.or]: [
           {
             name: {
-              [Op.iLike]: `%${like}%`,
+              [Op.iLike]: `%${query}%`,
             },
           },
           {
             description: {
-              [Op.iLike]: `%${like}%`,
+              [Op.iLike]: `%${query}%`,
             },
           },
         ],
@@ -112,68 +112,68 @@ router.get('/search', async (req, res, next) => {
 
 // GET /api/plants/:plantId
 router.get('/:plantId', async (req, res, next) => {
-	try {
-		const plant = await Plant.findByPk(req.params.plantId);
-		res.json(plant);
-	} catch (error) {
-		next(error);
-	}
+  try {
+    const plant = await Plant.findByPk(req.params.plantId);
+    res.json(plant);
+  } catch (error) {
+    next(error);
+  }
 });
 
 router.post('/', requireToken, isAdmin, async (req, res, next) => {
-	try {
-		const plant = await Plant.create(req.body);
-		res.json(plant);
-	} catch (err) {
-		next(err);
-	}
+  try {
+    const plant = await Plant.create(req.body);
+    res.json(plant);
+  } catch (err) {
+    next(err);
+  }
 });
 
 // requireToken, isAdmin,
 router.put('/:id', async (req, res, next) => {
-	try {
-		const oldPlant = await Plant.findOne({
-			where: {
-				id: req.params.id,
-			},
-		});
-		if (!oldPlant.active) {
-			throw new Error('Please update an active listing.');
-		}
+  try {
+    const oldPlant = await Plant.findOne({
+      where: {
+        id: req.params.id,
+      },
+    });
+    if (!oldPlant.active) {
+      throw new Error('Please update an active listing.');
+    }
 
-		const {name, species, price, imageURL, description, quantity} = oldPlant;
-		const whereStatement = {
-			name,
-			species,
-			price,
-			imageURL,
-			description,
-			quantity,
-			...req.body,
-		};
+    const { name, species, price, imageURL, description, quantity } = oldPlant;
+    const whereStatement = {
+      name,
+      species,
+      price,
+      imageURL,
+      description,
+      quantity,
+      ...req.body,
+    };
 
-		const [old, [newPlant, created]] = await Promise.all([
-			oldPlant.update({active: false}),
-			Plant.findOrCreate({
-				where: whereStatement,
-			}),
-		]);
+    const [old, [newPlant, created]] = await Promise.all([
+      oldPlant.update({ active: false }),
+      Plant.findOrCreate({
+        where: whereStatement,
+      }),
+    ]);
 
-		if (!created) await newPlant.update({active: true});
+    if (!created) await newPlant.update({ active: true });
 
-		res.json(newPlant);
-	} catch (err) {
-		next(err);
-	}
+    res.json(newPlant);
+  } catch (err) {
+    next(err);
+  }
 });
 
 router.delete('/:id', requireToken, isAdmin, async (req, res, next) => {
-	try {
-		const deleted = await Plant.destroy({where: {id: req.params.id}});
-		//check if breaks but send status only
-		// res.status(204).json(deleted);
-		res.sendStatus(204);
-	} catch (err) {
-		next(err);
-	}
+  try {
+    const deleted = await Plant.destroy({ where: { id: req.params.id } });
+    //check if breaks but send status only
+    // res.status(204).json(deleted);
+    res.sendStatus(204);
+  } catch (err) {
+    next(err);
+  }
 });


### PR DESCRIPTION
Now, instead of the NavBar handling the actual search functions, all it does is capture the search bar field and redirect to `/search?query=${whatWasSearched}`.

Then the searchResults component actually calls a thunkCreator and API route by checking its URL and sending the search field (`?query=whatWasSearched`) through. So when a user refreshes, the URL stays the same and it doesn't lose the plants.